### PR TITLE
Add support for invocation and node iteration on pointer types

### DIFF
--- a/src/meta/factory.hpp
+++ b/src/meta/factory.hpp
@@ -89,9 +89,11 @@ class factory {
             std::is_member_object_pointer_v<Type>,
             std::is_member_function_pointer_v<Type>,
             std::extent_v<Type>,
+            [](void* ptr) -> void* { return ptr; },
             []() -> meta::type { return internal::type_info<std::remove_pointer_t<Type>>::resolve(); },
             &internal::destroy<Type>,
-            []() -> meta::type { return &node; }
+            []() -> meta::type { return &node; },
+            []() -> internal::type_node* { return internal::type_info<std::remove_pointer_t<Type>>::resolve(); }
         };
 
         node.name = name;
@@ -620,7 +622,7 @@ inline bool unregister() noexcept {
  */
 template<typename Type>
 inline type resolve() noexcept {
-    return internal::type_info<Type>::resolve()->clazz();
+    return internal::type_info<Type>::resolve()->self();
 }
 
 
@@ -634,7 +636,7 @@ inline type resolve(const char *str) noexcept {
         return node->id == id;
     }, internal::type_info<>::type);
 
-    return curr ? curr->clazz() : type{};
+    return curr ? curr->self() : type{};
 }
 
 
@@ -646,7 +648,7 @@ inline type resolve(const char *str) noexcept {
 template<typename Op>
 void resolve(Op op) noexcept {
     internal::iterate([op = std::move(op)](auto *node) {
-        op(node->clazz());
+        op(node->self());
     }, internal::type_info<>::type);
 }
 

--- a/src/meta/meta.hpp
+++ b/src/meta/meta.hpp
@@ -2274,9 +2274,9 @@ type_node * info_node<Type>::resolve() noexcept {
             std::extent_v<Type>,
             [](void* ptr) -> void* {
                 if constexpr(std::is_pointer_v<Type>) {
-                    return *static_cast<Type*>(ptr);
+                    return reinterpret_cast<void*>(*reinterpret_cast<Type*>(ptr));
                 } else {
-                    return static_cast<Type*>(ptr);
+                    return reinterpret_cast<void*>(reinterpret_cast<Type*>(ptr));
                 }
             },
             []() -> meta::type { return internal::type_info<std::remove_pointer_t<Type>>::resolve(); },


### PR DESCRIPTION
This allows a `meta::any` or `meta::handle` to be invoked using the same syntax as a regular plain type. The conversion is performed automatically using `type_node::ptr` that converts a `void*` into a canonical form of `T*` for all types. `handle` now always stores the pointer in its canonical form.

What a `type` for a pointer does:
 - inherits `ctor`, `dtor`, `func`, `data` and `prop` from `T`
 - has it's own separate `conv` definitions (see note 2) although still not implemented, it should allow conversions from `T*` into `T` or `T*` into `T**` (this could be tricky since it might create an infinite recurring in template specializations).

What a `handle` for a pointer does:
 - Converts the `void*` into the canonical form and `node` is set to `clazz` (type `T`). Handles 

1. This *DOES NOT* support automatic conversion from `T*` to `T` for argument types as that should be implemented as a `conv` definition for the pointer types.
2. `T*` and `T` conversions are not merged, since the rules for conversion of these types are different (a user-defined conversion operator that convert A -> B cannot convert A* -> B*).
