### PR TITLE
fix ctor overload resolution

### DIFF
--- a/src/meta/meta.hpp
+++ b/src/meta/meta.hpp
@@ -468,7 +468,7 @@ public:
      */
     template<typename Type>
     inline bool can_cast() const noexcept {
-		const auto *type = internal::type_info<Type>::resolve();
+        const auto *type = internal::type_info<Type>::resolve();
         return internal::can_cast_or_convert<&internal::type_node::base>(node, type);
     }
 
@@ -1861,15 +1861,15 @@ public:
         any any{};
 
 #ifdef TODO_REMOVE_WHEN_MERGED_META_FIX_CTOR_OVERLOAD
-		internal::iterate<&internal::type_node::ctor>([data = arguments.data(), &any](auto * node) {
-			if (!any)
-				any = node->invoke(data);
-		}, node);
+        internal::iterate<&internal::type_node::ctor>([data = arguments.data(), &any](auto * node) {
+            if (!any)
+                any = node->invoke(data);
+        }, node);
 #else
-		internal::iterate<&internal::type_node::ctor>([data = arguments.data(), &any](auto * node) -> bool {
-			any = node->invoke(data);
-			return static_cast<bool>(any);
-		}, node);
+        internal::iterate<&internal::type_node::ctor>([data = arguments.data(), &any](auto * node) -> bool {
+            any = node->invoke(data);
+            return static_cast<bool>(any);
+        }, node);
 #endif
 
         return any;
@@ -2105,13 +2105,13 @@ inline bool destroy([[maybe_unused]] handle handle) {
 template<typename Type, typename... Args, std::size_t... Indexes>
 inline any construct(any * const args, std::index_sequence<Indexes...>) {
 #ifdef TODO_REMOVE_WHEN_MERGED_META_FIX_CTOR_OVERLOAD
-	[[maybe_unused]] std::array<bool, sizeof...(Args)> can_cast{{args == nullptr ? false : (args+Indexes)->can_cast<std::remove_cv_t<std::remove_reference_t<Args>>>()...}};
+    [[maybe_unused]] std::array<bool, sizeof...(Args)> can_cast{{args == nullptr ? false : (args+Indexes)->can_cast<std::remove_cv_t<std::remove_reference_t<Args>>>()...}};
     [[maybe_unused]] std::array<bool, sizeof...(Args)> can_convert{{args == nullptr ? false : (std::get<Indexes>(can_cast) ? false : (args+Indexes)->can_convert<std::remove_cv_t<std::remove_reference_t<Args>>>())...}};
 #else
-	[[maybe_unused]] std::array<bool, sizeof...(Args)> can_cast{{(args+Indexes)->can_cast<std::remove_cv_t<std::remove_reference_t<Args>>>()...}};
+    [[maybe_unused]] std::array<bool, sizeof...(Args)> can_cast{{(args+Indexes)->can_cast<std::remove_cv_t<std::remove_reference_t<Args>>>()...}};
     [[maybe_unused]] std::array<bool, sizeof...(Args)> can_convert{{(std::get<Indexes>(can_cast) ? false : (args+Indexes)->can_convert<std::remove_cv_t<std::remove_reference_t<Args>>>())...}};
 #endif
-	any any{};
+    any any{};
 
     if(((std::get<Indexes>(can_cast) || std::get<Indexes>(can_convert)) && ...)) {
         ((std::get<Indexes>(can_convert) ? void((args+Indexes)->convert<std::remove_cv_t<std::remove_reference_t<Args>>>()) : void()), ...);

--- a/src/meta/meta.hpp
+++ b/src/meta/meta.hpp
@@ -1860,17 +1860,10 @@ public:
         std::array<any, sizeof...(Args)> arguments{{std::forward<Args>(args)...}};
         any any{};
 
-#ifdef TODO_REMOVE_WHEN_MERGED_META_FIX_CTOR_OVERLOAD
-        internal::iterate<&internal::type_node::ctor>([data = arguments.data(), &any](auto * node) {
-            if (!any)
+        internal::iterate<&internal::type_node::ctor>([data = arguments.data(), &any, size=arguments.size()](auto * node) {
+            if (!any && node->size == size)
                 any = node->invoke(data);
         }, node);
-#else
-        internal::iterate<&internal::type_node::ctor>([data = arguments.data(), &any](auto * node) -> bool {
-            any = node->invoke(data);
-            return static_cast<bool>(any);
-        }, node);
-#endif
 
         return any;
     }
@@ -2104,13 +2097,8 @@ inline bool destroy([[maybe_unused]] handle handle) {
 
 template<typename Type, typename... Args, std::size_t... Indexes>
 inline any construct(any * const args, std::index_sequence<Indexes...>) {
-#ifdef TODO_REMOVE_WHEN_MERGED_META_FIX_CTOR_OVERLOAD
-    [[maybe_unused]] std::array<bool, sizeof...(Args)> can_cast{{args == nullptr ? false : (args+Indexes)->can_cast<std::remove_cv_t<std::remove_reference_t<Args>>>()...}};
-    [[maybe_unused]] std::array<bool, sizeof...(Args)> can_convert{{args == nullptr ? false : (std::get<Indexes>(can_cast) ? false : (args+Indexes)->can_convert<std::remove_cv_t<std::remove_reference_t<Args>>>())...}};
-#else
     [[maybe_unused]] std::array<bool, sizeof...(Args)> can_cast{{(args+Indexes)->can_cast<std::remove_cv_t<std::remove_reference_t<Args>>>()...}};
     [[maybe_unused]] std::array<bool, sizeof...(Args)> can_convert{{(std::get<Indexes>(can_cast) ? false : (args+Indexes)->can_convert<std::remove_cv_t<std::remove_reference_t<Args>>>())...}};
-#endif
     any any{};
 
     if(((std::get<Indexes>(can_cast) || std::get<Indexes>(can_convert)) && ...)) {

--- a/src/meta/meta.hpp
+++ b/src/meta/meta.hpp
@@ -468,7 +468,11 @@ public:
      */
     template<typename Type>
     inline bool can_cast() const noexcept {
-        const auto *type = internal::type_info<Type>::resolve();
+#ifdef TODO_REMOVE_WHEN_MERGED_META_FIX_CTOR_OVERLOAD
+		if (this == nullptr)
+			return false;
+#endif
+		const auto *type = internal::type_info<Type>::resolve();
         return internal::can_cast_or_convert<&internal::type_node::base>(node, type);
     }
 
@@ -518,6 +522,10 @@ public:
      */
     template<typename Type>
     inline bool can_convert() const noexcept {
+#ifdef TODO_REMOVE_WHEN_MERGED_META_FIX_CTOR_OVERLOAD
+		if (this == nullptr)
+			return false;
+#endif
         const auto *type = internal::type_info<Type>::resolve();
         return internal::can_cast_or_convert<&internal::type_node::conv>(node, type);
     }
@@ -1860,10 +1868,17 @@ public:
         std::array<any, sizeof...(Args)> arguments{{std::forward<Args>(args)...}};
         any any{};
 
-        internal::iterate<&internal::type_node::ctor>([data = arguments.data(), &any](auto *node) -> bool {
-            any = node->invoke(data);
-            return static_cast<bool>(any);
-        }, node);
+#ifdef TODO_REMOVE_WHEN_MERGED_META_FIX_CTOR_OVERLOAD
+		internal::iterate<&internal::type_node::ctor>([data = arguments.data(), &any](auto * node) {
+			if (!any)
+				any = node->invoke(data);
+		}, node);
+#else
+		internal::iterate<&internal::type_node::ctor>([data = arguments.data(), &any](auto * node) -> bool {
+			any = node->invoke(data);
+			return static_cast<bool>(any);
+		}, node);
+#endif
 
         return any;
     }

--- a/src/meta/meta.hpp
+++ b/src/meta/meta.hpp
@@ -468,10 +468,6 @@ public:
      */
     template<typename Type>
     inline bool can_cast() const noexcept {
-#ifdef TODO_REMOVE_WHEN_MERGED_META_FIX_CTOR_OVERLOAD
-		if (this == nullptr)
-			return false;
-#endif
 		const auto *type = internal::type_info<Type>::resolve();
         return internal::can_cast_or_convert<&internal::type_node::base>(node, type);
     }
@@ -522,10 +518,6 @@ public:
      */
     template<typename Type>
     inline bool can_convert() const noexcept {
-#ifdef TODO_REMOVE_WHEN_MERGED_META_FIX_CTOR_OVERLOAD
-		if (this == nullptr)
-			return false;
-#endif
         const auto *type = internal::type_info<Type>::resolve();
         return internal::can_cast_or_convert<&internal::type_node::conv>(node, type);
     }
@@ -2112,8 +2104,8 @@ inline bool destroy([[maybe_unused]] handle handle) {
 
 template<typename Type, typename... Args, std::size_t... Indexes>
 inline any construct(any * const args, std::index_sequence<Indexes...>) {
-    [[maybe_unused]] std::array<bool, sizeof...(Args)> can_cast{{(args+Indexes)->can_cast<std::remove_cv_t<std::remove_reference_t<Args>>>()...}};
-    [[maybe_unused]] std::array<bool, sizeof...(Args)> can_convert{{(std::get<Indexes>(can_cast) ? false : (args+Indexes)->can_convert<std::remove_cv_t<std::remove_reference_t<Args>>>())...}};
+    [[maybe_unused]] std::array<bool, sizeof...(Args)> can_cast{{args == nullptr ? false : (args+Indexes)->can_cast<std::remove_cv_t<std::remove_reference_t<Args>>>()...}};
+    [[maybe_unused]] std::array<bool, sizeof...(Args)> can_convert{{args == nullptr ? false : (std::get<Indexes>(can_cast) ? false : (args+Indexes)->can_convert<std::remove_cv_t<std::remove_reference_t<Args>>>())...}};
     any any{};
 
     if(((std::get<Indexes>(can_cast) || std::get<Indexes>(can_convert)) && ...)) {

--- a/src/meta/meta.hpp
+++ b/src/meta/meta.hpp
@@ -2104,9 +2104,14 @@ inline bool destroy([[maybe_unused]] handle handle) {
 
 template<typename Type, typename... Args, std::size_t... Indexes>
 inline any construct(any * const args, std::index_sequence<Indexes...>) {
-    [[maybe_unused]] std::array<bool, sizeof...(Args)> can_cast{{args == nullptr ? false : (args+Indexes)->can_cast<std::remove_cv_t<std::remove_reference_t<Args>>>()...}};
+#ifdef TODO_REMOVE_WHEN_MERGED_META_FIX_CTOR_OVERLOAD
+	[[maybe_unused]] std::array<bool, sizeof...(Args)> can_cast{{args == nullptr ? false : (args+Indexes)->can_cast<std::remove_cv_t<std::remove_reference_t<Args>>>()...}};
     [[maybe_unused]] std::array<bool, sizeof...(Args)> can_convert{{args == nullptr ? false : (std::get<Indexes>(can_cast) ? false : (args+Indexes)->can_convert<std::remove_cv_t<std::remove_reference_t<Args>>>())...}};
-    any any{};
+#else
+	[[maybe_unused]] std::array<bool, sizeof...(Args)> can_cast{{(args+Indexes)->can_cast<std::remove_cv_t<std::remove_reference_t<Args>>>()...}};
+    [[maybe_unused]] std::array<bool, sizeof...(Args)> can_convert{{(std::get<Indexes>(can_cast) ? false : (args+Indexes)->can_convert<std::remove_cv_t<std::remove_reference_t<Args>>>())...}};
+#endif
+	any any{};
 
     if(((std::get<Indexes>(can_cast) || std::get<Indexes>(can_convert)) && ...)) {
         ((std::get<Indexes>(can_convert) ? void((args+Indexes)->convert<std::remove_cv_t<std::remove_reference_t<Args>>>()) : void()), ...);

--- a/test/meta.cpp
+++ b/test/meta.cpp
@@ -146,8 +146,8 @@ struct Meta: public ::testing::Test {
 
         meta::reflect<fat_type>("fat")
                 .base<empty_type>()
-				.ctor<>()
-				.ctor<int*>()
+                .ctor<>()
+                .ctor<int*>()
                 .dtor<&fat_type::destroy>();
 
         meta::reflect<data_type>("data")
@@ -1402,19 +1402,19 @@ TEST_F(Meta, MetaTypeConstructCastAndConvert) {
 }
 
 TEST_F(Meta, MetaTypeConstructOverload) {
-	auto type = meta::resolve<fat_type>();
-	int x = 42;
-	auto any1 = type.construct();
-	auto any2 = type.construct(&x);
+    auto type = meta::resolve<fat_type>();
+    int x = 42;
+    auto any1 = type.construct();
+    auto any2 = type.construct(&x);
 
-	ASSERT_TRUE(any1);
-	ASSERT_TRUE(any2);
-	ASSERT_TRUE(any1.can_cast<fat_type>());
-	ASSERT_TRUE(any2.can_cast<fat_type>());
-	ASSERT_EQ(any1.cast<fat_type>().foo, nullptr);
-	ASSERT_EQ(any1.cast<fat_type>().bar, nullptr);
-	ASSERT_EQ(any2.cast<fat_type>().foo, &x);
-	ASSERT_EQ(any2.cast<fat_type>().bar, &x);
+    ASSERT_TRUE(any1);
+    ASSERT_TRUE(any2);
+    ASSERT_TRUE(any1.can_cast<fat_type>());
+    ASSERT_TRUE(any2.can_cast<fat_type>());
+    ASSERT_EQ(any1.cast<fat_type>().foo, nullptr);
+    ASSERT_EQ(any1.cast<fat_type>().bar, nullptr);
+    ASSERT_EQ(any2.cast<fat_type>().foo, &x);
+    ASSERT_EQ(any2.cast<fat_type>().bar, &x);
 }
 
 

--- a/test/meta.cpp
+++ b/test/meta.cpp
@@ -1,5 +1,6 @@
 #include <type_traits>
 #include <gtest/gtest.h>
+#define TODO_REMOVE_WHEN_MERGED_META_FIX_CTOR_OVERLOAD
 #include <meta/factory.hpp>
 #include <meta/meta.hpp>
 
@@ -145,6 +146,8 @@ struct Meta: public ::testing::Test {
 
         meta::reflect<fat_type>("fat")
                 .base<empty_type>()
+				.ctor<>()
+				.ctor<int*>()
                 .dtor<&fat_type::destroy>();
 
         meta::reflect<data_type>("data")
@@ -1396,6 +1399,22 @@ TEST_F(Meta, MetaTypeConstructCastAndConvert) {
     ASSERT_TRUE(any.can_cast<derived_type>());
     ASSERT_EQ(any.cast<derived_type>().i, 42);
     ASSERT_EQ(any.cast<derived_type>().c, 'c');
+}
+
+TEST_F(Meta, MetaTypeConstructOverload) {
+	auto type = meta::resolve<fat_type>();
+	int x = 42;
+	auto any1 = type.construct();
+	auto any2 = type.construct(&x);
+
+	ASSERT_TRUE(any1);
+	ASSERT_TRUE(any2);
+	ASSERT_TRUE(any1.can_cast<fat_type>());
+	ASSERT_TRUE(any2.can_cast<fat_type>());
+	ASSERT_EQ(any1.cast<fat_type>().foo, nullptr);
+	ASSERT_EQ(any1.cast<fat_type>().bar, nullptr);
+	ASSERT_EQ(any2.cast<fat_type>().foo, &x);
+	ASSERT_EQ(any2.cast<fat_type>().bar, &x);
 }
 
 

--- a/test/meta.cpp
+++ b/test/meta.cpp
@@ -1,6 +1,5 @@
 #include <type_traits>
 #include <gtest/gtest.h>
-#define TODO_REMOVE_WHEN_MERGED_META_FIX_CTOR_OVERLOAD
 #include <meta/factory.hpp>
 #include <meta/meta.hpp>
 
@@ -26,6 +25,10 @@ struct fat_type: empty_type {
         : foo{value}, bar{value}
     {}
 
+    fat_type(int* value1, int* value2)
+        : foo{ value1 }, bar{ value2 }
+    {}
+    
     int *foo{nullptr};
     int *bar{nullptr};
 
@@ -148,6 +151,7 @@ struct Meta: public ::testing::Test {
                 .base<empty_type>()
                 .ctor<>()
                 .ctor<int*>()
+                .ctor<int*, int*>()
                 .dtor<&fat_type::destroy>();
 
         meta::reflect<data_type>("data")
@@ -1403,18 +1407,23 @@ TEST_F(Meta, MetaTypeConstructCastAndConvert) {
 
 TEST_F(Meta, MetaTypeConstructOverload) {
     auto type = meta::resolve<fat_type>();
-    int x = 42;
+    int x = 42, y = 24;
     auto any1 = type.construct();
     auto any2 = type.construct(&x);
+    auto any3 = type.construct(&x, &y);
 
     ASSERT_TRUE(any1);
     ASSERT_TRUE(any2);
+    ASSERT_TRUE(any3);
     ASSERT_TRUE(any1.can_cast<fat_type>());
     ASSERT_TRUE(any2.can_cast<fat_type>());
+    ASSERT_TRUE(any3.can_cast<fat_type>());
     ASSERT_EQ(any1.cast<fat_type>().foo, nullptr);
     ASSERT_EQ(any1.cast<fat_type>().bar, nullptr);
     ASSERT_EQ(any2.cast<fat_type>().foo, &x);
     ASSERT_EQ(any2.cast<fat_type>().bar, &x);
+    ASSERT_EQ(any3.cast<fat_type>().foo, &x);
+    ASSERT_EQ(any3.cast<fat_type>().bar, &y);
 }
 
 


### PR DESCRIPTION
Ciao Michele @skypjack,

first of all my compliments for your great work!!! I've a lot to learn from your code....

I found a minor problem with constructors:
when more ctors are reflected all of them actually run, so the any returned is the one from the last ctor reflected. My fix stops to apply them when the first "valid" one has done.

There was also issues when the default constructor is in the overload candidates because in this case nullptr was passed to can_cast<>() and can_convert()

I wrote also a test to check the bug.
There is a macro defined at the beginning of test file. you can comment out it to reproduce the issue.