### PR TITLE
The default ctor of meta::factory should be public.

### DIFF
--- a/src/meta/factory.hpp
+++ b/src/meta/factory.hpp
@@ -320,9 +320,9 @@ class factory {
         }
     }
 
+public:
     factory() noexcept = default;
 
-public:
     /**
      * @brief Extends a meta type by assigning it an identifier and properties.
      * @tparam Property Types of properties to assign to the meta type.


### PR DESCRIPTION
Fixes a compilation issue in C++20, where the `factory{}` initializer used by the `meta::reflect` helper function (and possibly elsewher) invokes the default costructor instead of using aggregate initialization as it does in C++17 and earlier.