### PR TITLE
Remove compare fn

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# meta uses space indentation
+[*.{hpp,cpp}]
+indent_style = space
+indent_size = 4

--- a/src/meta/meta.hpp
+++ b/src/meta/meta.hpp
@@ -623,7 +623,7 @@ public:
      * otherwise.
      */
     bool operator==(const any &other) const noexcept {
-        return node == other.node && node->compare(instance, other.instance);
+        return node == other.node && (!node || node->compare(instance, other.instance));
     }
 
     /**

--- a/src/meta/meta.hpp
+++ b/src/meta/meta.hpp
@@ -623,7 +623,7 @@ public:
      * otherwise.
      */
     bool operator==(const any &other) const noexcept {
-        return node == other.node && (!node->compare || (node->compare)(instance, other.instance));
+        return node == other.node && node->compare(instance, other.instance);
     }
 
     /**
@@ -2090,7 +2090,15 @@ inline type_node * info_node<Type>::resolve() noexcept {
                 return &node;
             },
             [](const void* lhs, const void* rhs) noexcept {
-                return compare(0, *static_cast<const Type*>(lhs), *static_cast<const Type*>(rhs));
+                if constexpr (std::is_void_v<Type>)
+                {
+                    return true;
+                }
+                else
+                {
+                    // extra parens to prevent ADL, just in case
+                    return (compare)(0, *static_cast<const Type*>(lhs), *static_cast<const Type*>(rhs));
+                }
             }
         };
 

--- a/src/meta/meta.hpp
+++ b/src/meta/meta.hpp
@@ -2094,6 +2094,11 @@ inline type_node * info_node<Type>::resolve() noexcept {
                 {
                     return true;
                 }
+                else if constexpr (std::is_function_v<Type>)
+                {
+                    // functions only compare equal with themselves
+                    return lhs == rhs;
+                }
                 else
                 {
                     // extra parens to prevent ADL, just in case


### PR DESCRIPTION
The comparison function pointer stored in meta::any might be moved to meta::type_node.