### PR TITLE
Detection of cast to meta::any type

### DIFF
--- a/src/meta/factory.hpp
+++ b/src/meta/factory.hpp
@@ -210,6 +210,8 @@ any invoke([[maybe_unused]] handle handle, any *args, std::index_sequence<Indexe
     [[maybe_unused]] const auto direct = std::make_tuple([](meta::any *any, auto *instance) {
         using arg_type = std::remove_reference_t<decltype(*instance)>;
 
+        if constexpr (std::is_same_v<arg_type, meta::any>)
+            return any;
         if(!instance && any->convert<arg_type>()) {
             instance = any->try_cast<arg_type>();
         }

--- a/src/meta/meta.hpp
+++ b/src/meta/meta.hpp
@@ -238,24 +238,20 @@ auto find_if(Op op, const type_node *node) noexcept
 
 template<typename Type>
 const Type * try_cast(const type_node *node, void *instance) noexcept {
-    if constexpr (std::is_same_v<Type, meta::any>)
-        return reinterpret_cast<const meta::any *>(instance);
-    else {
-        const auto *type = type_info<Type>::resolve();
-        void *ret = nullptr;
+    const auto *type = type_info<Type>::resolve();
+    void *ret = nullptr;
 
-        if(node == type) {
-            ret = instance;
-        } else {
-            const auto *base = find_if<&type_node::base>([type](auto *candidate) {
-                return candidate->ref() == type;
-            }, node);
+    if(node == type) {
+        ret = instance;
+    } else {
+        const auto *base = find_if<&type_node::base>([type](auto *candidate) {
+            return candidate->ref() == type;
+        }, node);
 
-            ret = base ? base->cast(instance) : nullptr;
-        }
-
-        return static_cast<const Type *>(ret);
+        ret = base ? base->cast(instance) : nullptr;
     }
+
+    return static_cast<const Type *>(ret);
 }
 
 

--- a/src/meta/meta.hpp
+++ b/src/meta/meta.hpp
@@ -238,20 +238,24 @@ auto find_if(Op op, const type_node *node) noexcept
 
 template<typename Type>
 const Type * try_cast(const type_node *node, void *instance) noexcept {
-    const auto *type = type_info<Type>::resolve();
-    void *ret = nullptr;
+    if constexpr (std::is_same_v<Type, meta::any>)
+        return reinterpret_cast<const meta::any *>(instance);
+    else {
+        const auto *type = type_info<Type>::resolve();
+        void *ret = nullptr;
 
-    if(node == type) {
-        ret = instance;
-    } else {
-        const auto *base = find_if<&type_node::base>([type](auto *candidate) {
-            return candidate->ref() == type;
-        }, node);
+        if(node == type) {
+            ret = instance;
+        } else {
+            const auto *base = find_if<&type_node::base>([type](auto *candidate) {
+                return candidate->ref() == type;
+            }, node);
 
-        ret = base ? base->cast(instance) : nullptr;
+            ret = base ? base->cast(instance) : nullptr;
+        }
+
+        return static_cast<const Type *>(ret);
     }
-
-    return static_cast<const Type *>(ret);
 }
 
 


### PR DESCRIPTION
Hello,
First, thank you for this high quality library, it is very pleasant to read your code !

After playing a bit with the meta system, I found that I couldn't call meta-functions using **meta::any** as **parameter** (due to bad cast).

<del>This patch check in the 'try_cast' implementation if the target type is a **meta::any** and if so, returns it.<del>

This allows me to use your beautiful **meta::any** to create reflected containers of any type for my script language :)

Edit: The patch is now in **meta::internal::invoke** because it'd cause a crash (dangling reference) in try_cast if the passed parameter type isn't matching **meta::any**.